### PR TITLE
Add request status screen

### DIFF
--- a/public/ko.svg
+++ b/public/ko.svg
@@ -1,0 +1,5 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="15" fill="#EA1F46"/>
+<path d="M10 10L20 20" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20 10L10 20" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/ok.svg
+++ b/public/ok.svg
@@ -1,0 +1,4 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="15" fill="#37AD4B"/>
+<path d="M20 10L13.125 20L10 15.4545" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/Header.css
+++ b/src/Header.css
@@ -1,4 +1,5 @@
 .Header {
     padding-top: 50px;
-    font-size: 1.5rem;
+    padding-bottom: 50px;
+    font-size: 1.2rem;
 }

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
     return (
         <Row className="Header">
             <Col md={3}>
-                <Logo size={ 170 } />
+                <Logo size={ 120 } />
             </Col>
             <Col>
                 <Row>

--- a/src/RequestStatus.css
+++ b/src/RequestStatus.css
@@ -1,0 +1,9 @@
+.RequestStatus {
+    text-align: center;
+}
+
+.RequestStatus h2 {
+    font-size: 1.2rem;
+    font-weight: bold;
+    margin-bottom: 1.2rem;
+}

--- a/src/RequestStatus.tsx
+++ b/src/RequestStatus.tsx
@@ -1,0 +1,51 @@
+import { LocRequestState, RejectedRequest } from "@logion/client";
+import { useCallback, useMemo } from "react";
+import { Button } from "react-bootstrap";
+import config from './config/index';
+import StatusIcon, { isPending, isRecorded, isRejected } from "./StatusIcon";
+import "./RequestStatus.css";
+import ButtonBar from "./ButtonBar";
+
+export interface Props {
+    request: LocRequestState;
+}
+
+export default function RequestStatus(props: Props) {
+
+    const status = useMemo(() => props.request.data().status, [ props.request ]);
+
+    const restart = useCallback(async () => {
+        if(props.request instanceof RejectedRequest) {
+            await props.request.cancel();
+            // TODO refresh
+        }
+    }, [ props.request ]);
+
+    return (
+        <div className="RequestStatus">
+            <h2>Identity LOC request status</h2>
+            <StatusIcon status={ status }/>
+            {
+                isPending(status) &&
+                <p>Pending</p>
+            }
+            {
+                isRejected(status) &&
+                <>
+                    <p>Rejected.</p>
+                    <p>Reason: { props.request.data().rejectReason }</p>
+                    <ButtonBar>
+                        <Button onClick={ restart }>Restart the process</Button>
+                    </ButtonBar>
+                </>
+            }
+            {
+                isRecorded(status) &&
+                <>
+                    <p>Your identity credentials are recorded by logion.</p>
+                    <p><a href={ `https://${ config.certificateHost }/public/certificate/${ props.request.data().id.toDecimalString() }` }>Identity LOC Certificate</a></p>
+                </>
+            }
+        </div>
+    );
+}

--- a/src/StatusIcon.css
+++ b/src/StatusIcon.css
@@ -1,0 +1,14 @@
+.StatusIcon {
+    display: inline-block;
+    height: 64px;
+    width: 64px;
+    border-radius: 32px;
+}
+
+.StatusIcon.pending {
+    background-color: orange;
+}
+
+.StatusIcon.unknown {
+    background-color: black;
+}

--- a/src/StatusIcon.tsx
+++ b/src/StatusIcon.tsx
@@ -1,0 +1,30 @@
+import { LocRequestStatus } from "@logion/client";
+import "./StatusIcon.css";
+
+export interface Props {
+    status: LocRequestStatus;
+}
+
+export default function StatusIcon(props: Props) {
+    if(isPending(props.status)) {
+        return <p className="StatusIcon pending"></p>;
+    } else if(isRecorded(props.status)) {
+        return <p className="StatusIcon recorded"><img src={ `${process.env.PUBLIC_URL}/ok.svg` } height={64} alt="recorded icon"/></p>;
+    } else if(isRejected(props.status)) {
+        return <p className="StatusIcon rejected"><img src={ `${process.env.PUBLIC_URL}/ko.svg` } height={64} alt="rejected icon"/></p>;
+    } else {
+        return <p className="StatusIcon unknown"></p>;
+    }
+}
+
+export function isPending(status: LocRequestStatus) {
+    return status === "REQUESTED" || status === "OPEN";
+}
+
+export function isRecorded(status: LocRequestStatus) {
+    return status === "CLOSED";
+}
+
+export function isRejected(status: LocRequestStatus) {
+    return status === "REJECTED";
+}

--- a/src/config/development.json.sample
+++ b/src/config/development.json.sample
@@ -14,5 +14,6 @@
             "peerId": "12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ",
             "socket": "ws://localhost:9946"
         }
-    ]
+    ],
+    "certificateHost": "localhost:8080"
 }

--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -10,6 +10,7 @@ export interface ConfigType {
     RPC: object,
     directory: string,
     edgeNodes: Node[],
+    certificateHost: string,
 }
 
 export const DEFAULT_CONFIG: ConfigType = {
@@ -19,6 +20,7 @@ export const DEFAULT_CONFIG: ConfigType = {
     },
     directory: "",
     edgeNodes: [],
+    certificateHost: "certificate.logion.network",
 };
 
 export interface EnvConfigType extends Record<string, any> {


### PR DESCRIPTION
* Adds screens indicating request status (pending, recorded, rejected)
* Screen selection logic is overly complex but prevents unused imports one would get by commenting code
* Certificate host name must be configured

logion-network/logion-internal#876